### PR TITLE
update the computation of scores and errors

### DIFF
--- a/eval/test_one_solution.py
+++ b/eval/test_one_solution.py
@@ -24,14 +24,13 @@ def print_results(results, args):
     per_prob_res = []
     all_correct = []
     for index in results:
-       res.extend(np.array(results[index]))
-       per_prob_res.append(np.mean(results[index] > 0))
-       all_correct.append(np.all(results[index] > 0))
-    tmp_results = np.array(res)
-    compile_errors = len(tmp_results[tmp_results==-2])
-    runtime_errors = len(tmp_results[tmp_results==-1])
-    failures = len(tmp_results[tmp_results==False])
-    successes = len(tmp_results[tmp_results==True])
+        var = np.array(results[index])
+        res.extend(var)
+        per_prob_res.append(np.mean(var)>0)
+        all_correct.append(np.all(var)>0)
+    compile_errors = len([e for e in res if -2 in e])
+    # we count runtime for multiple tests as one
+    runtime_errors = len([e for e in res if -1 in e])
     total_testcases = len(res)
     if args.debug:
         print(f"number of compile errors = {compile_errors} avg = {compile_errors / total_testcases }")


### PR DESCRIPTION
Hi @xksteven, following on our discussion yesterday #11, I just had the chance to run the changes on actual solutions and there are some problems
* Given that we added `>0` to average and strict accuracy `result[index]` needs to be an array for these computations too to avoid this error:
```
 per_prob_res.append(np.mean(results[index] > 0))
TypeError: '>' not supported between instances of 'list' and 'int'
```

* Setting `tmp_results` to `np.array(res)` to do elementwise comparison directly fails with some examples, as `tmp_results` is the output for problems that might have different number of tests, which makes the second dimension of the « array » not constant making the element wise comparison to fail. (doesn't work either with adding `dtype=object`)
```
VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
  tmp_results = np.array(res)
/home/loubna_huggingface_co/datasets/pr.py:146: DeprecationWarning: elementwise comparison failed; this will raise an error in the future. compile_errors = len(tmp_results[tmp_results==-2])
```
I changed this to use lists, the compilation error happens once per problem `[[-2]]`, the results will be slightly different for runtime errors as in this case we assume if the runtime error happens for one test it also does for the other tests  (looking at some examples it seems to be the case) so we count it as one runtime error per problem.

Feel free to run more tests or if you have another suggestion to fix this.