### PR TITLE
fix pyext for python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Used for evaluation and some common for train too
 numpy
-pyext>=0.7
+git+https://github.com/clefourrier/pyext
 sacrebleu # we used 1.5.1
 sacremoses # we used 0.0.45
 torch>=1.7


### PR DESCRIPTION
pyext no longer installs on 3.11 because of changes to inspect; this fork fixes the install issue.